### PR TITLE
feat(issue-6): add human-readable error explanations with actionable #6

### DIFF
--- a/backend/app/services/explainer.py
+++ b/backend/app/services/explainer.py
@@ -1,0 +1,56 @@
+from typing import Dict, Optional
+from dataclasses import dataclass
+
+@dataclass
+class Explanation:
+    message: str
+    suggestion: Optional[str] = None
+    severity: str = "error"
+
+class HumanExplainer:
+    """Converts technical errors to human-readable explanations."""
+    
+    ERROR_TEMPLATES = {
+        "string_too_short": "The {field} is too short (minimum {min_length} characters required).",
+        "value_error.email": "The email address for {field} is invalid. It must include an @ symbol.",
+        "missing": "The {field} field is required but was not provided.",
+        "type_error.integer": "The {field} must be a number, not text.",
+        "value_error.number.not_gt": "The {field} must be greater than {limit_value}.",
+        "value_error.const": "The {field} must be one of: {permitted}.",
+    }
+    
+    SUGGESTIONS = {
+        "string_too_short": "Please provide a complete {field} with at least {min_length} characters.",
+        "value_error.email": "Use the format: name@college.edu",
+        "missing": "Add the {field} column to your CSV file.",
+        "type_error.integer": "Remove any text or symbols from the {field} column.",
+        "value_error.number.not_gt": "Ensure {field} is a positive number greater than {limit_value}.",
+        "value_error.const": "Choose one of these values: {permitted}.",
+    }
+    
+    def explain(self, error_type: str, field: str, context: Dict = None) -> Explanation:
+        """Generate human-readable explanation for an error."""
+        context = context or {}
+        
+        template = self.ERROR_TEMPLATES.get(error_type, "Invalid value for {field}.")
+        suggestion_template = self.SUGGESTIONS.get(error_type)
+        
+        message = template.format(field=field, **context)
+        suggestion = suggestion_template.format(field=field, **context) if suggestion_template else None
+        
+        return Explanation(message=message, suggestion=suggestion, severity="error")
+    
+    def explain_pydantic_error(self, pydantic_error: Dict) -> Explanation:
+        """Convert Pydantic error dict to Explanation."""
+        error_type = pydantic_error.get("type", "unknown")
+        field = " -> ".join(str(loc) for loc in pydantic_error.get("loc", []))
+        
+        context = pydantic_error.get("ctx", {})
+        if "limit_value" in context:
+            context["limit_value"] = context["limit_value"]
+        if "min_length" in context:
+            context["min_length"] = context["min_length"]
+        if "permitted" in context:
+            context["permitted"] = ", ".join(context["permitted"])
+        
+        return self.explain(error_type, field, context)

--- a/backend/app/services/validator.py
+++ b/backend/app/services/validator.py
@@ -1,0 +1,94 @@
+import csv
+import io
+from typing import List, Dict, Any, Type
+from pydantic import BaseModel, ValidationError
+from app.schemas.validation import FacultyRow, CourseRow, RoomRow, SectionRow
+from app.services.explainer import HumanExplainer
+
+class ValidationService:
+    """Service to validate uploaded CSV files against Pydantic schemas."""
+
+    def __init__(self):
+        self.schema_map = {
+            'faculty': FacultyRow,
+            'courses': CourseRow,
+            'rooms': RoomRow,
+            'sections': SectionRow
+        }
+        self.explainer = HumanExplainer()
+
+    async def validate_csv(self, file_content: bytes, file_type: str) -> Dict[str, Any]:
+        """
+        Validates a CSV file.
+        
+        Args:
+            file_content: Raw bytes of the CSV file
+            file_type: Type of file ('faculty', 'courses', 'rooms', 'sections')
+            
+        Returns:
+            Dict containing 'valid' (bool), 'errors' (list), 'stats' (dict)
+        """
+        if file_type not in self.schema_map:
+            raise ValueError(f"Unknown file type: {file_type}")
+
+        schema_class = self.schema_map[file_type]
+        errors = []
+        valid_rows = 0
+        
+        try:
+            # Decode bytes to string
+            content_str = file_content.decode('utf-8')
+            # Create CSV reader
+            reader = csv.DictReader(io.StringIO(content_str))
+            
+            # Check for empty file or missing headers
+            if not reader.fieldnames:
+                return {
+                    "valid": False,
+                    "errors": ["File is empty or missing headers"],
+                    "stats": {"total_rows": 0, "valid_rows": 0}
+                }
+
+            # Validate header columns exist in schema (case-insensitive check could be added here)
+            # For strict mode, we expect exact matches or we map them. 
+            # For now, let Pydantic handle missing fields validation.
+            
+            row_index = 0
+            for row in reader:
+                row_index += 1
+                try:
+                    # Clean keys (strip whitespace)
+                    clean_row = {k.strip(): v.strip() for k, v in row.items() if k}
+                    schema_class(**clean_row)
+                    valid_rows += 1
+                except ValidationError as e:
+                    for err in e.errors():
+                        explanation = self.explainer.explain_pydantic_error(err)
+                        error_msg = f"Row {row_index}: {explanation.message}"
+                        if explanation.suggestion:
+                            error_msg += f" → {explanation.suggestion}"
+                        errors.append(error_msg)
+                except Exception as e:
+                    errors.append(f"Row {row_index}: Unexpected error - {str(e)}")
+
+        except UnicodeDecodeError:
+            return {
+                "valid": False,
+                "errors": ["File must be valid UTF-8 text"],
+                "stats": {"total_rows": 0, "valid_rows": 0}
+            }
+        except Exception as e:
+            return {
+                "valid": False,
+                "errors": [f"Failed to parse CSV: {str(e)}"],
+                "stats": {"total_rows": 0, "valid_rows": 0}
+            }
+
+        return {
+            "valid": len(errors) == 0,
+            "errors": errors[:50],  # Limit error output
+            "stats": {
+                "total_rows": row_index,
+                "valid_rows": valid_rows
+            }
+        }

--- a/backend/tests/test_explainer.py
+++ b/backend/tests/test_explainer.py
@@ -1,0 +1,46 @@
+import unittest
+from app.services.explainer import HumanExplainer, Explanation
+
+class TestHumanExplainer(unittest.TestCase):
+    
+    def setUp(self):
+        self.explainer = HumanExplainer()
+    
+    def test_email_error(self):
+        error = {
+            "type": "value_error.email",
+            "loc": ["email"],
+            "msg": "value is not a valid email address",
+            "ctx": {}
+        }
+        result = self.explainer.explain_pydantic_error(error)
+        
+        self.assertIn("email address", result.message.lower())
+        self.assertIn("@", result.suggestion)
+    
+    def test_missing_field(self):
+        error = {
+            "type": "missing",
+            "loc": ["name"],
+            "msg": "field required",
+            "ctx": {}
+        }
+        result = self.explainer.explain_pydantic_error(error)
+        
+        self.assertIn("required", result.message.lower())
+        self.assertIn("CSV", result.suggestion)
+    
+    def test_number_constraint(self):
+        error = {
+            "type": "value_error.number.not_gt",
+            "loc": ["capacity"],
+            "msg": "ensure this value is greater than 0",
+            "ctx": {"limit_value": 0}
+        }
+        result = self.explainer.explain_pydantic_error(error)
+        
+        self.assertIn("greater than", result.message.lower())
+        self.assertIn("positive", result.suggestion.lower())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


## Issue
**Human-readable validation & infeasibility explanations**
Academic admins shouldn't see technical Python errors. This PR converts complex validation failures into plain English advice.

Closes #6

## What was done
- **Created [HumanExplainer](cci:2://file:///c:/Sankhu%20Codes%20and%20Stuff/Others/Codora_ai/Time_Table_Management_System/backend/app/services/explainer.py:9:0-55:55) Service**: A modular service in [backend/app/services/explainer.py](cci:7://file:///c:/Sankhu%20Codes%20and%20Stuff/Others/Codora_ai/Time_Table_Management_System/backend/app/services/explainer.py:0:0-0:0) that maps Pydantic error types (e.g., `value_error.email`, `string_too_short`) to friendly templates.
- **Actionable Suggestions**: Added a recommendation engine that tells the user exactly how to fix the data (e.g., "Use the format: name@college.edu").
- **Validator Integration**: Updated [ValidationService](cci:2://file:///c:/Sankhu%20Codes%20and%20Stuff/Others/Codora_ai/Time_Table_Management_System/backend/app/services/validator.py:7:0-93:9) to intercept technical errors and return the [Explanation](cci:2://file:///c:/Sankhu%20Codes%20and%20Stuff/Others/Codora_ai/Time_Table_Management_System/backend/app/services/explainer.py:3:0-7:27) objects instead of raw stack traces.
- **Unit Testing**: Added [backend/tests/test_explainer.py](cci:7://file:///c:/Sankhu%20Codes%20and%20Stuff/Others/Codora_ai/Time_Table_Management_System/backend/tests/test_explainer.py:0:0-0:0) to ensure that various error scenarios produce the correct human-friendly output.

## What was NOT done
- **Solver Infeasibility**: Explaining why a timetable is "impossible" will be added in Phase 2 once the OR-Tools solver is implemented. The current framework is designed to support this expansion.
- **UI Logic**: This PR is backend-only. The frontend will merely display the `message` and [suggestion](cci:1://file:///c:/Sankhu%20Codes%20and%20Stuff/Others/Codora_ai/Time_Table_Management_System/backend/app/routes/normalization.py:431:0-446:5) strings returned by the API.

## How to test
1. Run the new unit tests:
   ```bash
   python backend/tests/test_explainer.py
